### PR TITLE
DNE-45-Add-Remove-Liquidity-Action

### DIFF
--- a/dne-frontend/src/components/swapBar/SwapBar.tsx
+++ b/dne-frontend/src/components/swapBar/SwapBar.tsx
@@ -24,7 +24,9 @@ interface InputAmountProps {
 
 interface ButtonBarProps {
     supply: boolean;
-    handleClick: () => void;
+    handleSwap: () => void;
+    handleAddLiquidity?: () => void;
+    handleRemoveLiquidity?: () => void;
 }
 
 
@@ -123,21 +125,34 @@ const Switch = ({checked, setChecked}: SwitchProps) => {
     )
 }
 
-export const ButtonBar = ({supply, handleClick}: ButtonBarProps) => (
-    <div className={styles.buttonBarContainer} onClick={handleClick}>
-        {supply ? <SupplyButtons /> : <SwapButton />}
+export const ButtonBar = ({supply, handleSwap, handleAddLiquidity, handleRemoveLiquidity}: ButtonBarProps) => (
+    <div className={styles.buttonBarContainer}>
+        {supply ? <SupplyButtons handleAddLiquidity={handleAddLiquidity} handleRemoveLiquidity={handleRemoveLiquidity}/> : <SwapButton handleSwap={handleSwap}/>}
     </div>
 )
 
-const SwapButton = () => (
-    <div>
+interface SwapButtonProps {
+    handleSwap: () => void;
+}
+
+const SwapButton = ({handleSwap}:SwapButtonProps) => (
+    <div onClick={handleSwap}>
         <button className={styles.swapBarButton}>Swap</button>
     </div>
 )
 
-const SupplyButtons = () => (
+interface SupplyButtonsProps {
+    handleAddLiquidity?: () => void;
+    handleRemoveLiquidity?: () => void;
+}
+
+const SupplyButtons = ({handleAddLiquidity, handleRemoveLiquidity}:SupplyButtonsProps) => (
     <div className={styles.swapBarButtonContainer}>
-        <button className={styles.swapBarButton}>Supply</button>
-        <button className={styles.swapBarButton}>Remove</button>
+        <button className={styles.swapBarButton}
+                onClick={handleAddLiquidity}
+        >Supply</button>
+        <button className={styles.swapBarButton}
+                onClick={handleRemoveLiquidity}
+        >Remove</button>
     </div>
 )

--- a/dne-frontend/src/pages/Pools.tsx
+++ b/dne-frontend/src/pages/Pools.tsx
@@ -94,7 +94,6 @@ const Pools = () => {
                 for (const lp of liquidityPools) {
                     const mintA = new PublicKey(lp.tokenA);
                     const metadataA = await getTokenMetadata(connection, mintA);
-                    console.log("Token A Metadata:", metadataA);
                     const mintB = new PublicKey(lp.tokenB);
                     const metadataB = await getTokenMetadata(connection, mintB);
                     const poolData:Pool = {

--- a/dne-frontend/src/pages/SwapScreen.tsx
+++ b/dne-frontend/src/pages/SwapScreen.tsx
@@ -369,6 +369,77 @@ const Swap = () => {
         }
     }
 
+    const handleAddLiquidity = async () => {
+        console.log("Add Liquidity");
+
+        if (!wallet || !poolAddress || !poolMetaData) {
+            console.error("Wallet or pool address is missing");
+            return;
+        }
+
+        const mintAPub =  new PublicKey(poolMetaData.tokenA.address);
+        const mintBPub = new PublicKey(poolMetaData.tokenB.address);
+        const lpTokenPub = new PublicKey(poolMetaData.lpToken.address);
+        const walletPub = new PublicKey(wallet.publicKey);
+        const poolPub = new PublicKey(poolAddress);
+
+        const {
+            userTokenAccountA,
+            userTokenAccountB,
+            lpTokenAPda,
+            lpTokenBPda,
+        } = await getAssociatedAddresses(
+            program,
+            mintAPub,
+            mintBPub,
+            lpTokenPub,
+            walletPub
+        );
+
+        console.log("userTokenAccountA", userTokenAccountA.toBase58());
+        console.log("userTokenAccountB", userTokenAccountB.toBase58());
+        console.log("lpTokenAPda", lpTokenAPda.toBase58());
+        console.log("lpTokenBPda", lpTokenBPda.toBase58());
+
+
+    }
+
+    const handleRemoveLiquidity = async () => {
+        console.log("Remove Liquidity");
+
+
+        if (!wallet || !poolAddress || !poolMetaData) {
+            console.error("Wallet or pool address is missing");
+            return;
+        }
+
+        const mintAPub =  new PublicKey(poolMetaData.tokenA.address);
+        const mintBPub = new PublicKey(poolMetaData.tokenB.address);
+        const lpTokenPub = new PublicKey(poolMetaData.lpToken.address);
+        const walletPub = new PublicKey(wallet.publicKey);
+        const poolPub = new PublicKey(poolAddress);
+
+        const {
+            userTokenAccountA,
+            userTokenAccountB,
+            lpTokenAPda,
+            lpTokenBPda,
+        } = await getAssociatedAddresses(
+            program,
+            mintAPub,
+            mintBPub,
+            lpTokenPub,
+            walletPub
+        );
+
+        console.log("userTokenAccountA", userTokenAccountA.toBase58());
+        console.log("userTokenAccountB", userTokenAccountB.toBase58());
+        console.log("lpTokenAPda", lpTokenAPda.toBase58());
+        console.log("lpTokenBPda", lpTokenBPda.toBase58());
+
+
+    }
+
     return (
         <div className={styles.page}>
             <SwitchBar checked={swapOrSupply} setChecked={setSwapOrSupply} />
@@ -398,7 +469,11 @@ const Swap = () => {
                 : (<div className={styles.spacer}></div>)
 
             }
-            <ButtonBar supply={swapOrSupply} handleClick={handleSwap}/>
+            <ButtonBar supply={swapOrSupply}
+                       handleSwap={handleSwap}
+                       handleAddLiquidity={handleAddLiquidity}
+                       handleRemoveLiquidity={handleRemoveLiquidity}
+            />
         </div>
     )
 };

--- a/dne-frontend/src/pages/SwapScreen.tsx
+++ b/dne-frontend/src/pages/SwapScreen.tsx
@@ -320,7 +320,7 @@ const Swap = () => {
         lpTokenLPPDA?: PublicKey;
     }
 
-    const handlePoolAction(action:PoolAction) {
+    const handlePoolAction = async (action:PoolAction) => {
         if (!wallet || !poolAddress || !poolMetaData) {
             console.error("Wallet or pool address is missing");
             return;
@@ -363,7 +363,11 @@ const Swap = () => {
         }
 
         if (action === PoolAction.Swap) {
-            handleSwap(poolProps);
+            await handleSwap(poolProps);
+        } else if (action === PoolAction.AddLiquidity) {
+            await handleAddLiquidity(poolProps);
+        } else if (action === PoolAction.RemoveLiquidity) {
+            await handleRemoveLiquidity(poolProps);
         }
     }
 
@@ -417,74 +421,13 @@ const Swap = () => {
         }
     }
 
-    const handleAddLiquidity = async () => {
+    const handleAddLiquidity = async (props:poolActionProps) => {
         console.log("Add Liquidity");
-
-        if (!wallet || !poolAddress || !poolMetaData) {
-            console.error("Wallet or pool address is missing");
-            return;
-        }
-
-        const mintAPub =  new PublicKey(poolMetaData.tokenA.address);
-        const mintBPub = new PublicKey(poolMetaData.tokenB.address);
-        const lpTokenPub = new PublicKey(poolMetaData.lpToken.address);
-        const walletPub = new PublicKey(wallet.publicKey);
-        const poolPub = new PublicKey(poolAddress);
-
-        const {
-            userTokenAccountA,
-            userTokenAccountB,
-            lpTokenAPda,
-            lpTokenBPda,
-        } = await getAssociatedAddresses(
-            program,
-            mintAPub,
-            mintBPub,
-            lpTokenPub,
-            walletPub
-        );
-
-        console.log("userTokenAccountA", userTokenAccountA.toBase58());
-        console.log("userTokenAccountB", userTokenAccountB.toBase58());
-        console.log("lpTokenAPda", lpTokenAPda.toBase58());
-        console.log("lpTokenBPda", lpTokenBPda.toBase58());
-
 
     }
 
-    const handleRemoveLiquidity = async () => {
+    const handleRemoveLiquidity = async (props:poolActionProps) => {
         console.log("Remove Liquidity");
-
-
-        if (!wallet || !poolAddress || !poolMetaData) {
-            console.error("Wallet or pool address is missing");
-            return;
-        }
-
-        const mintAPub =  new PublicKey(poolMetaData.tokenA.address);
-        const mintBPub = new PublicKey(poolMetaData.tokenB.address);
-        const lpTokenPub = new PublicKey(poolMetaData.lpToken.address);
-        const walletPub = new PublicKey(wallet.publicKey);
-        const poolPub = new PublicKey(poolAddress);
-
-        const {
-            userTokenAccountA,
-            userTokenAccountB,
-            lpTokenAPda,
-            lpTokenBPda,
-        } = await getAssociatedAddresses(
-            program,
-            mintAPub,
-            mintBPub,
-            lpTokenPub,
-            walletPub
-        );
-
-        console.log("userTokenAccountA", userTokenAccountA.toBase58());
-        console.log("userTokenAccountB", userTokenAccountB.toBase58());
-        console.log("lpTokenAPda", lpTokenAPda.toBase58());
-        console.log("lpTokenBPda", lpTokenBPda.toBase58());
-
 
     }
 
@@ -518,9 +461,9 @@ const Swap = () => {
 
             }
             <ButtonBar supply={swapOrSupply}
-                       handleSwap={handleSwap}
-                       handleAddLiquidity={handleAddLiquidity}
-                       handleRemoveLiquidity={handleRemoveLiquidity}
+                       handleSwap={() => handlePoolAction(PoolAction.Swap)}
+                       handleAddLiquidity={() => handlePoolAction(PoolAction.AddLiquidity)}
+                       handleRemoveLiquidity={() => handlePoolAction(PoolAction.RemoveLiquidity)}
             />
         </div>
     )

--- a/onchain/scripts/createNewPool.ts
+++ b/onchain/scripts/createNewPool.ts
@@ -267,7 +267,7 @@ const main = async () => {
     const user_account = (provider.wallet as NodeWallet).payer;
 
     // This should be the wallet address of the account doing the swap.
-    const wallet_address = new PublicKey("B34XtRbwgkN2Kjrr61in8qC2ArniemrxuDzAZJUL3T4o")
+    const wallet_address = new PublicKey("7YZDbhkRFYSFo1xqV5eS8hiairc8rEiVDTWFioBp3ef5")
 
     // Create mints for Token A and Token B via MPL metadata.
     const tokenAMetadata = {


### PR DESCRIPTION
We can now do all of the token swapping actions. There are some minor changes that need to be made like updating the tokens to be from the power of 6 or 9 or whatever it is. We also should provide feedback to the user so that we can tell that the actions have been completed. Right now they are just printing to the log. Lastly, We should consider using a fresh keypair to launch, as there is a lot of clutter of the accounts from testing. 

Still. This marks the completion of a user being able to Swap, Add, and Remove liquidity from a pool. A huge achievement.